### PR TITLE
Bug that was introduced in PR#4

### DIFF
--- a/src/lib/classes/saml_client.php
+++ b/src/lib/classes/saml_client.php
@@ -184,7 +184,7 @@ class SAML_Client
     if(array_key_exists($this->settings->get_attribute('groups'), $attrs) )
     {
       foreach(wp_roles()->roles as $role_name => $role_meta){
-          if( in_array($this->settings->get_group($role_name),$attrs[$this->settings->get_attribute('groups')]) )
+          if( !isset($role) && in_array($this->settings->get_group($role_name),$attrs[$this->settings->get_attribute('groups')]) )
           {
             $role = $role_name;
           }

--- a/src/lib/views/sso_sp.php
+++ b/src/lib/views/sso_sp.php
@@ -130,7 +130,8 @@
   </tr>
   </table>
   <h3>Groups</h3>
-  <p>You don't have to fill in all of these, but you should have at least one. Users will get their WordPress permissions based on the highest-ranking group they are members of.</p>
+  <p>You don't have to fill in all of these, but you should have at least one. Users will get their WordPress Role based the first matching group in the list below, this usually goes from Administrator to Subscriber. </p>
+  <p>There's currently an <a href="https://github.com/ktbartholomew/saml-20-single-sign-on/issues/8">issue on GitHub</a> that will implement better control on what order of this list will have.</p>
   <table class="form-table">
   <?php foreach(wp_roles()->roles as $role_name => $role_meta): ?>
   <tr>


### PR DESCRIPTION
Set the role to the first role it matches.

WP orders the roles from Admin -> Subscriber.
So if a user belongs to two AD groups that's mapped to administrator and subscriber, then it's most likely that the user belongs to the administrator role.

Previously when it looped through the WP roles it set the role to the last one in the list, because there were no check if the role already were set.
